### PR TITLE
Add Quantum-Entropic Strategist V3 Common Lisp module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ market scenarios while keeping the runtime deterministic and auditable.
 │   ├── __init__.py          # Convenience exports for the Freysa agent
 │   └── freysa_agent.py      # Core deterministic agent implementation
 ├── freysa0.py               # CLI utilities for running simulations
+├── quantum_strat_v3.lisp    # Quantum-Entropic Strategist module (Common Lisp)
 ├── tests/                   # Test suite
 ├── pyproject.toml           # Project configuration
 ├── LICENSE
@@ -29,6 +30,12 @@ memory log, and produces structured status snapshots after each reasoning cycle.
 The script offers a command-line interface around the agent to make it easy to
 run repeatable simulations from JSON scenario files. It includes helpers to
 summarize the resulting state and to generate a starter scenario template.
+
+
+### `quantum_strat_v3.lisp`
+A standalone Common Lisp module implementing the user-requested Cognitive Layer
+V3 "Quantum-Entropic Strategist" with CLOS state objects, entropy-driven signal
+collapse, strategy generation, and an executable startup loop.
 
 ## Getting started
 

--- a/quantum_strat_v3.lisp
+++ b/quantum_strat_v3.lisp
@@ -1,0 +1,219 @@
+;; ======================================================================
+;; COGNITIVE LAYER V3: QUANTUM-ENTROPIC STRATEGIST (COMPLETE)
+;; UPGRADES: CLOS Architecture, Wave-Function Collapse, Entropic Scaling
+;; ======================================================================
+
+(defpackage :quantum-strat
+  (:use :cl)
+  (:export :initialize-system :run-quantum-cycle :generate-quantum-key))
+
+(in-package :quantum-strat)
+
+;; --- 1. CLOS DEFINITIONS (STATE ENCAPSULATION) ---
+
+(defclass cognitive-core ()
+  ((epoch :initform 0 :accessor epoch)
+   (learning-rate :initform 0.08 :accessor learning-rate)
+   (neural-weights :initform '(0.24 0.78 0.52) :accessor neural-weights)
+   (knowledge-base :initarg :kb :accessor kb)))
+
+(defclass portfolio ()
+  ((balance :initform 1.15e77 :accessor balance)
+   (positions :initform nil :accessor positions)
+   (risk-coeff :initform 0.01 :accessor risk-coeff)))
+
+(defclass market-state ()
+  ((entropy :initform 0.1 :accessor entropy)
+   (signal-vector :initform '(0.0 0.0 0.0) :accessor signal-vector)))
+
+(defclass session ()
+  ((api-key :initarg :key :accessor api-key)
+   (auth-level :initform :omega-tier :accessor auth-level)))
+
+;; --- 2. GLOBAL ENVIRONMENT ---
+
+(defvar *core* nil)
+(defvar *port* nil)
+(defvar *market* nil)
+(defvar *session* nil)
+(defvar *api-registry* (make-hash-table :test 'equal))
+
+(defun initialize-system ()
+  "Bootstraps the V3 CLOS environment."
+  (setf *core*
+        (make-instance
+         'cognitive-core
+         :kb
+         '((:id 1 :concept "Momentum" :vector (0.8 0.2 0.1))
+           (:id 2 :concept "Mean Reversion" :vector (0.1 0.9 0.2))
+           (:id 3 :concept "Risk Parity" :vector (0.3 0.3 0.9))
+           (:id 4 :concept "LLM-Sentiment" :vector (0.5 0.5 0.5))
+           (:id 5 :concept "Black Swan" :vector (0.9 0.1 0.8)))))
+  (setf *port* (make-instance 'portfolio))
+  (setf *market* (make-instance 'market-state))
+  (format t "[SYSTEM] V3 Quantum-Entropic Core Initialized.~%"))
+
+;; --- 3. AUTHENTICATION & LIQUIDITY ---
+
+(defun generate-quantum-key (user-id)
+  "Generates an entangled API Key."
+  (let ((key (format nil "INF-Q-~A-~X" user-id (random 1000000000))))
+    (setf (gethash key *api-registry*) t)
+    (format t "[AUTH] Quantum Key Forged: ~A~%" key)
+    key))
+
+(defun authenticate (key)
+  "Validates key presence before wave-function collapse."
+  (if (gethash key *api-registry*)
+      (progn
+        (setf *session* (make-instance 'session :key key))
+        (format t "[SECURE] Session Established. Tier: ~A~%"
+                (auth-level *session*)))
+      (error "QUANTUM COLLAPSE: Unauthorized Key Intrusion.")))
+
+;; --- 4. ADVANCED MATHEMATICS & SUPERPOSITION ---
+
+(defun dot-product (v1 v2)
+  (loop for x in v1
+        for y in v2
+        sum (* x y)))
+
+(defun magnitude (v)
+  (sqrt (loop for x in v
+              sum (* x x))))
+
+(defun cosine-similarity (v1 v2)
+  (let ((mag (* (magnitude v1) (magnitude v2))))
+    (if (zerop mag)
+        0.0
+        (/ (dot-product v1 v2) mag))))
+
+(defun softmax (vec)
+  (let* ((exps (mapcar #'exp vec))
+         (sum (reduce #'+ exps)))
+    (mapcar (lambda (x) (/ x sum)) exps)))
+
+(defun collapse-wave-function (base-signal entropy-level)
+  "Applies entropic jitter to simulate evaluating all market states simultaneously."
+  (mapcar (lambda (x)
+            (let ((jitter (* (- (random 2.0) 1.0) entropy-level)))
+              (max 0.0 (min 1.0 (+ x jitter)))))
+          base-signal))
+
+;; --- 5. COGNITIVE ENGINE ---
+
+(defun retrieve-context (query-vec top-k)
+  (let ((scored-kb
+          (mapcar (lambda (item)
+                    (append item
+                            (list :score
+                                  (cosine-similarity (getf item :vector)
+                                                     query-vec))))
+                  (kb *core*))))
+    (subseq (sort scored-kb #'> :key (lambda (x) (getf x :score)))
+            0
+            (min top-k (length scored-kb)))))
+
+(defun neural-forward-pass (input-vector weights)
+  (/ 1 (+ 1 (exp (- (loop for i in input-vector
+                          for w in weights
+                          sum (* i w)))))))
+
+(defun multi-agent-consensus (signal)
+  "Internal V3 consensus logic using the triplet agent heuristic."
+  (let* ((weights '((0.9 0.1 0.1) (0.1 0.9 0.1) (0.4 0.4 0.4)))
+         (votes (mapcar (lambda (w) (dot-product signal w)) weights)))
+    (softmax votes)))
+
+(defun generate-omega-strategy (context)
+  (let ((top-concept (getf (first context) :concept))
+        (trust-score
+          (cosine-similarity (getf (first context) :vector)
+                             '(1.0 1.0 1.0))))
+    (format nil "STRATEGY-OMEGA: ~A [Resonance: ~,2F%]"
+            (string-upcase top-concept)
+            (* trust-score 100))))
+
+(defun backpropagate (target-signal actual-output)
+  (let* ((error (- target-signal actual-output))
+         (lr (learning-rate *core*))
+         (new-weights (mapcar (lambda (w) (+ w (* lr error)))
+                              (neural-weights *core*))))
+    (setf (neural-weights *core*) new-weights)
+    (format t "[NEURAL] Synaptic weights adjusted. Delta: ~,4F~%" error)))
+
+;; --- 6. ENTROPIC EXECUTION LAYER ---
+
+(defun execute-quantum-trade (action base-amount confidence)
+  "Scales trade size dynamically based on market entropy (chaos)."
+  (unless *session*
+    (error "Execution Denied: No Active Session."))
+  (let* ((current-entropy (entropy *market*))
+         (entropic-modifier (- 1.0 current-entropy))
+         (actual-amount (* base-amount confidence entropic-modifier))
+         (bal (balance *port*)))
+    (if (>= bal actual-amount)
+        (progn
+          (setf (balance *port*) (- bal actual-amount))
+          (format t "[LEDGER] ~A ~A units. Entropic Dampening: ~,2F~%"
+                  action
+                  (round actual-amount)
+                  entropic-modifier))
+        (format t "[LEDGER] Liquidity collapse. Cannot execute.~%"))))
+
+;; --- 7. MAIN RECURSIVE LOOP ---
+
+(defun run-quantum-cycle (api-key)
+  "The full loop: Sensing -> Collapse -> Reason -> Execute -> Learn"
+  (authenticate api-key)
+  (incf (epoch *core*))
+
+  (setf (entropy *market*) (random 0.4)) ;; Simulate market chaos
+
+  (format t "~%==================================================~%")
+  (format t ">>> EPOCH ~A | ENTROPY LEVEL: ~,3F <<<~%"
+          (epoch *core*)
+          (entropy *market*))
+  (format t "==================================================~%")
+
+  (let* ((raw-signal (list (random 1.0) (random 1.0) (random 1.0)))
+         ;; 1. Wave Function Collapse
+         (observed-signal (collapse-wave-function raw-signal (entropy *market*)))
+
+         ;; 2. Knowledge Retrieval
+         (context (retrieve-context observed-signal 3))
+         (strat-msg (generate-omega-strategy context))
+
+         ;; 3. Agent & Neural Inference
+         (agent-opinion (multi-agent-consensus observed-signal))
+         (inference
+           (neural-forward-pass observed-signal (neural-weights *core*)))
+
+         ;; 4. Scoring logic
+         (final-score (* inference (reduce #'+ agent-opinion))))
+
+    (format t "[REASONING] ~A~%" strat-msg)
+    (format t "[SIGNAL] Inference Coherence: ~,4F~%" inference)
+
+    ;; 5. Decision & Execution
+    (cond ((> final-score 0.7)
+           (execute-quantum-trade 'LONG-STAKE 1.0e12 final-score))
+          ((< final-score 0.3)
+           (execute-quantum-trade 'SHORT-HEDGE 5.0e11 final-score))
+          (t
+           (format t "[HOLD] Signal resonance insufficient (~,4F)~%"
+                   final-score)))
+
+    ;; 6. Backpropagation (Learning toward an idealized state)
+    (backpropagate 0.8 inference)))
+
+;; ======================================================================
+;; STARTUP SEQUENCE
+;; ======================================================================
+
+(initialize-system)
+
+(defparameter *v3-key* (generate-quantum-key "OVERLORD-01"))
+
+;; Running multiple cycles to observe the entropic scaling and weight adjustments
+(loop repeat 3 do (run-quantum-cycle *v3-key*))


### PR DESCRIPTION
### Motivation
- Provide the requested Cognitive Layer V3 implementation as a standalone Common Lisp module so the app can host the "Quantum-Entropic Strategist" prototype and make it discoverable in the repository.
- Keep the implementation self-contained with CLOS-based state, entropy-driven signal processing, and an executable startup loop to allow local experimentation and inspection.

### Description
- Added `quantum_strat_v3.lisp`, a Common Lisp module that defines CLOS classes (`cognitive-core`, `portfolio`, `market-state`, `session`) and exports `initialize-system`, `run-quantum-cycle`, and `generate-quantum-key` for bootstrapping and execution.
- Implemented vector math and inference utilities (`dot-product`, `magnitude`, `cosine-similarity`, `softmax`), a `collapse-wave-function` entropic jitter, retrieval/inference/backpropagation logic, and an entropic trade execution layer with a recursive `run-quantum-cycle` loop.
- Updated `README.md` to list `quantum_strat_v3.lisp` in the project layout and to include a short module description for discoverability.

### Testing
- Ran the repository test suite with `pytest -q`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c370f094832793e6f0a190012e82)