### PR TITLE
Enhance Freysa simulation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ market scenarios while keeping the runtime deterministic and auditable.
 The module exposes the `FreysaSentientAI` class, a deterministic agent core that
 operates on simple oracle payloads containing price feeds and textual messages.
 It supports dependency injection for clocks and limiter policies, keeps a bounded
-memory log, and produces structured status snapshots after each reasoning cycle.
+memory log, normalizes incoming oracle payloads, and produces structured status
+snapshots with deterministic market insights after each reasoning cycle.
 
 ### `freysa0.py`
 The script offers a command-line interface around the agent to make it easy to
@@ -62,13 +63,23 @@ If you only need a concise view, use the `--summary` flag:
 python freysa0.py scenario.json --summary
 ```
 
+For a full run with a compact event-count section before the memory dump, add
+`--events`:
+
+```
+python freysa0.py scenario.json --events
+```
+
 ### 3. Interpreting the results
 
 Each cycle status includes:
 - the agent metadata (`name`, `version`, deterministic `id`),
 - the internal state snapshot (awareness, health, inputs, etc.),
 - the average asset price for the current cycle (when available),
-- the most recent message seen by the agent, and
+- a `market_insight` block with asset count, min/max assets, spread, trend,
+  risk level, and spike detection,
+- the most recent normalized message seen by the agent,
+- deterministic event counts, and
 - how many memory entries are currently stored.
 
 The memory log at the end reveals every logged event in chronological order,
@@ -93,6 +104,8 @@ pytest
   matches your environment.
 - Build higher-level analytics by importing the `FreysaSimulation` class from
   `freysa0.py` and embedding it into larger evaluation pipelines.
+- Use `FreysaSentientAI.recent_memory()` and `event_counts()` for lightweight
+  diagnostics without parsing a full memory export.
 
 ## License
 

--- a/agents/freysa_agent.py
+++ b/agents/freysa_agent.py
@@ -1,13 +1,18 @@
 # freysa_agent.py
 """
-Deterministic, hardware-agnostic agent skeleton for the freysa.ai
-TEE / on-chain environment.
+Deterministic, hardware-agnostic agent core for repeatable Freysa simulations.
+
+The module intentionally keeps all reasoning local and auditable: every cycle
+normalizes oracle inputs, derives a compact market insight, updates state through
+an injected limiter policy, and records the path in a bounded memory log.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
+from collections import Counter
 from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Dict, List, Optional, Protocol, TypeAlias, final
 
@@ -17,12 +22,14 @@ JSON: TypeAlias = Dict[str, Any]
 #  Protocols / small pluggable helpers
 # --------------------------------------------------------------------------- #
 class Clock(Protocol):
-    """Return an integer UNIX epoch second – must be deterministic inside TEE."""
+    """Return an integer UNIX epoch second; deterministic clocks are preferred."""
+
     def now(self) -> int: ...
 
 
 class Limiter(Protocol):
-    """Return True if the agent should act given current inputs."""
+    """Return True if the agent should move from idle to active."""
+
     def spike(self, price_feed: Dict[str, float]) -> bool: ...
 
 
@@ -38,6 +45,25 @@ class InputBundle:
         return asdict(self)
 
 
+@dataclass(slots=True, frozen=True)
+class MarketInsight:
+    """Deterministic summary of the most recent oracle price feed."""
+
+    asset_count: int = 0
+    average_price: Optional[float] = None
+    min_asset: Optional[str] = None
+    min_price: Optional[float] = None
+    max_asset: Optional[str] = None
+    max_price: Optional[float] = None
+    spread: Optional[float] = None
+    trend: str = "unknown"
+    risk_level: str = "unknown"
+    spike_detected: bool = False
+
+    def to_json(self) -> JSON:
+        return asdict(self)
+
+
 @dataclass(slots=True)
 class SelfState:
     awareness: str = "observing"
@@ -45,6 +71,7 @@ class SelfState:
     health: str = "idle"
     inputs: InputBundle = field(default_factory=InputBundle)
     cycle_count: int = 0
+    last_insight: MarketInsight = field(default_factory=MarketInsight)
 
     def snapshot(self) -> JSON:
         return asdict(self)
@@ -62,7 +89,8 @@ class LogEntry:
 #  Default deterministic helpers
 # --------------------------------------------------------------------------- #
 class StaticClock:
-    """A trivial deterministic clock – must be injected by caller per cycle."""
+    """A trivial deterministic clock that callers may advance per cycle."""
+
     def __init__(self, initial: int = 0) -> None:
         self._t = initial
 
@@ -75,7 +103,8 @@ class StaticClock:
 
 
 class SimpleLimiter:
-    """Reference implementation of Limiter with hard-coded thresholds."""
+    """Reference limiter with deterministic hard-coded spike thresholds."""
+
     BTC_SPIKE = 690_000_000_000
     ETH_SPIKE = 3_140_000_000
     AVG_SPIKE = 6_290_000_000.0
@@ -88,6 +117,30 @@ class SimpleLimiter:
         eth = price_feed.get("ETH", 0) > self.ETH_SPIKE
         return avg_price > self.AVG_SPIKE or btc or eth
 
+    def explain(self, price_feed: Dict[str, float]) -> JSON:
+        """Expose threshold comparisons for audit trails and status snapshots."""
+        if not price_feed:
+            return {
+                "spike": False,
+                "average_price": None,
+                "triggered_thresholds": [],
+            }
+
+        avg_price = sum(price_feed.values()) / len(price_feed)
+        triggered = []
+        if avg_price > self.AVG_SPIKE:
+            triggered.append("AVG_SPIKE")
+        if price_feed.get("BTC", 0) > self.BTC_SPIKE:
+            triggered.append("BTC_SPIKE")
+        if price_feed.get("ETH", 0) > self.ETH_SPIKE:
+            triggered.append("ETH_SPIKE")
+
+        return {
+            "spike": bool(triggered),
+            "average_price": round(avg_price, 2),
+            "triggered_thresholds": triggered,
+        }
+
 
 # --------------------------------------------------------------------------- #
 #  Main Agent
@@ -95,6 +148,7 @@ class SimpleLimiter:
 @final
 class FreysaSentientAI:
     MAX_MEMORY: Optional[int] = 2_048  # smaller default for on-chain cost
+    MAX_MESSAGE_LENGTH = 512
 
     def __init__(
         self,
@@ -113,6 +167,7 @@ class FreysaSentientAI:
 
         self.state = SelfState()
         self.memory: List[LogEntry] = []
+        self._previous_avg_price: Optional[float] = None
 
         # Genesis event always at t=0
         self._log("boot", {"agent_id": self.id, "version": self.version}, timestamp=0)
@@ -136,6 +191,7 @@ class FreysaSentientAI:
             return self.get_status()
 
         self._ingest_oracle(oracle_payload, timestamp=now)
+        self._analyze_market(timestamp=now)
         self._reflect(timestamp=now)
         self._self_update(timestamp=now)  # decides final health
         return self.get_status()
@@ -151,21 +207,34 @@ class FreysaSentientAI:
     def reset_memory(self) -> None:
         self.memory.clear()
         self.state = SelfState()
+        self._previous_avg_price = None
         self._log("reset", {"agent_id": self.id}, timestamp=0)
 
     def get_status(self) -> JSON:
-        pf = self.state.inputs.price_feed or {}
         messages = self.state.inputs.messages or []
-        avg_price = round(sum(pf.values()) / len(pf), 2) if pf else None
+        insight = self.state.last_insight
         return {
             "name": self.name,
             "version": self.version,
             "id": self.id,
             "state": self.state.snapshot(),
-            "avg_price": avg_price,
+            "avg_price": insight.average_price,
             "last_message": messages[-1] if messages else None,
+            "market_insight": insight.to_json(),
             "memory_length": len(self.memory),
+            "event_counts": self.event_counts(),
         }
+
+    def event_counts(self) -> Dict[str, int]:
+        """Return deterministic counts of logged event types."""
+        return dict(sorted(Counter(entry.event for entry in self.memory).items()))
+
+    def recent_memory(self, limit: int = 5, *, event: Optional[str] = None) -> List[JSON]:
+        """Return the most recent memory entries, optionally filtered by event."""
+        if limit < 1:
+            return []
+        entries = [entry for entry in self.memory if event is None or entry.event == event]
+        return [asdict(entry) for entry in entries[-limit:]]
 
     # ------------------------------------------------------------------- #
     #  Internal helpers
@@ -174,53 +243,151 @@ class FreysaSentientAI:
         """Validate and store incoming oracle data deterministically."""
         allowed = {f.name for f in fields(InputBundle)}
         filtered = {k: payload[k] for k in payload if k in allowed}
+        ignored = sorted(k for k in payload if k not in allowed)
+        if ignored:
+            self._log("warn", {"reason": "ignored oracle fields", "fields": ignored}, timestamp=timestamp)
 
-        # -- price feed -------------------------------------------------- #
-        pf_raw = filtered.get("price_feed")
-        price_feed: Optional[Dict[str, float]] = self._validate_price_feed(pf_raw, timestamp)
-
-        # -- messages ---------------------------------------------------- #
-        msgs_raw = filtered.get("messages")
-        messages: Optional[List[str]] = self._validate_messages(msgs_raw, timestamp)
+        price_feed = self._validate_price_feed(filtered.get("price_feed"), timestamp)
+        messages = self._validate_messages(filtered.get("messages"), timestamp)
 
         self.state.inputs = InputBundle(price_feed=price_feed, messages=messages)
         self._log("oracle_input", self.state.inputs.to_json(), timestamp=timestamp)
 
     def _validate_price_feed(self, pf_raw: Any, timestamp: int) -> Optional[Dict[str, float]]:
-        if isinstance(pf_raw, dict):
+        if pf_raw is None:
+            return None
+        if not isinstance(pf_raw, dict):
+            self._log("warn", {"reason": "price_feed not dict"}, timestamp=timestamp)
+            return None
+
+        normalized: Dict[str, float] = {}
+        rejected: List[str] = []
+        for asset, value in pf_raw.items():
+            symbol = str(asset).strip().upper()
             try:
-                return {k: float(v) for k, v in pf_raw.items()}
+                price = float(value)
             except (ValueError, TypeError):
-                self._log("warn", {"reason": "non-numeric price values"}, timestamp=timestamp)
-        else:
-            if pf_raw is not None:
-                self._log("warn", {"reason": "price_feed not dict"}, timestamp=timestamp)
-        return None
+                rejected.append(str(asset))
+                continue
+            if not symbol or not math.isfinite(price) or price < 0:
+                rejected.append(str(asset))
+                continue
+            normalized[symbol] = price
+
+        if rejected:
+            self._log(
+                "warn",
+                {"reason": "invalid price values", "assets": sorted(rejected)},
+                timestamp=timestamp,
+            )
+        return normalized or None
 
     def _validate_messages(self, msgs_raw: Any, timestamp: int) -> Optional[List[str]]:
-        if isinstance(msgs_raw, list) and all(isinstance(m, str) for m in msgs_raw):
-            return msgs_raw
-        else:
-            if msgs_raw is not None:
-                self._log("warn", {"reason": "messages not list[str]"}, timestamp=timestamp)
-        return None
+        if msgs_raw is None:
+            return None
+        if not isinstance(msgs_raw, list):
+            self._log("warn", {"reason": "messages not list[str]"}, timestamp=timestamp)
+            return None
+
+        messages: List[str] = []
+        rejected = 0
+        truncated = 0
+        for raw in msgs_raw:
+            if not isinstance(raw, str):
+                rejected += 1
+                continue
+            message = raw.strip()
+            if not message:
+                rejected += 1
+                continue
+            if len(message) > self.MAX_MESSAGE_LENGTH:
+                message = message[: self.MAX_MESSAGE_LENGTH]
+                truncated += 1
+            messages.append(message)
+
+        if rejected or truncated:
+            self._log(
+                "warn",
+                {
+                    "reason": "message normalization",
+                    "rejected": rejected,
+                    "truncated": truncated,
+                },
+                timestamp=timestamp,
+            )
+        return messages or None
+
+    def _analyze_market(self, *, timestamp: int) -> None:
+        """Build a compact, deterministic insight from the normalized feed."""
+        pf = self.state.inputs.price_feed or {}
+        if not pf:
+            self.state.last_insight = MarketInsight()
+            self._log("market_analysis", self.state.last_insight.to_json(), timestamp=timestamp)
+            return
+
+        sorted_prices = sorted(pf.items())
+        avg_price = round(sum(price for _, price in sorted_prices) / len(sorted_prices), 2)
+        min_asset, min_price = min(sorted_prices, key=lambda item: (item[1], item[0]))
+        max_asset, max_price = max(sorted_prices, key=lambda item: (item[1], item[0]))
+        spike_detected = self.limiter.spike(pf)
+        trend = self._trend(avg_price)
+        risk_level = self._risk_level(spike_detected, trend)
+
+        self.state.last_insight = MarketInsight(
+            asset_count=len(sorted_prices),
+            average_price=avg_price,
+            min_asset=min_asset,
+            min_price=round(min_price, 2),
+            max_asset=max_asset,
+            max_price=round(max_price, 2),
+            spread=round(max_price - min_price, 2),
+            trend=trend,
+            risk_level=risk_level,
+            spike_detected=spike_detected,
+        )
+        self._previous_avg_price = avg_price
+        self._log("market_analysis", self.state.last_insight.to_json(), timestamp=timestamp)
+
+    def _trend(self, avg_price: float) -> str:
+        if self._previous_avg_price is None:
+            return "baseline"
+        if avg_price > self._previous_avg_price:
+            return "rising"
+        if avg_price < self._previous_avg_price:
+            return "falling"
+        return "flat"
+
+    @staticmethod
+    def _risk_level(spike_detected: bool, trend: str) -> str:
+        if spike_detected and trend == "rising":
+            return "critical"
+        if spike_detected:
+            return "elevated"
+        if trend == "rising":
+            return "watch"
+        return "normal"
 
     def _reflect(self, *, timestamp: int) -> None:
-        """Lightweight metacognition placeholder."""
+        """Lightweight metacognition placeholder with concrete recent context."""
         last_event = self.memory[-1].event if self.memory else "none"
-        thought = f"reflecting on {last_event}"
+        insight = self.state.last_insight
+        thought = f"reflecting on {last_event}; market risk is {insight.risk_level}"
         self.state.awareness = "reflecting"
         self._log("reflect", {"thought": thought}, timestamp=timestamp)
         self.state.awareness = "observing"
 
     def _self_update(self, *, timestamp: int) -> None:
         """Adjust internal health/state based on limiter policy."""
-        pf = self.state.inputs.price_feed or {}
-        high_activity = self.limiter.spike(pf)
+        insight = self.state.last_insight
+        high_activity = insight.spike_detected
 
         action = "high market activity" if high_activity else "normal range"
         self.state.health = "active" if high_activity else "idle"
-        self._log("self_update", {"action": action}, timestamp=timestamp)
+        self._log(
+            "self_update",
+            {"action": action, "risk_level": insight.risk_level, "trend": insight.trend},
+            timestamp=timestamp,
+        )
 
     # ------------------------------------------------------------------- #
     #  Logging

--- a/freysa0.py
+++ b/freysa0.py
@@ -86,14 +86,43 @@ class SimulationResult:
         cycles = len(self.statuses)
         last_state = self.statuses[-1]["state"] if self.statuses else {}
         last_health = last_state.get("health")
-        avg_prices = [status.get("avg_price") for status in self.statuses if status.get("avg_price")]
+        avg_prices = [status.get("avg_price") for status in self.statuses if status.get("avg_price") is not None]
         avg_price = sum(avg_prices) / len(avg_prices) if avg_prices else None
+        risk_levels = [
+            status.get("market_insight", {}).get("risk_level")
+            for status in self.statuses
+            if status.get("market_insight")
+        ]
+        health_counts = _count_values(
+            status.get("state", {}).get("health") for status in self.statuses
+        )
+        risk_counts = _count_values(risk_levels)
+        memory_entries = json.loads(self.memory_dump) if self.memory_dump else []
+        event_counts = _count_values(entry.get("event") for entry in memory_entries)
         return {
             "cycles": cycles,
             "last_health": last_health,
             "avg_price_mean": round(avg_price, 2) if avg_price is not None else None,
-            "memory_entries": len(json.loads(self.memory_dump) if self.memory_dump else []),
+            "spike_cycles": sum(
+                1 for status in self.statuses if status.get("market_insight", {}).get("spike_detected")
+            ),
+            "health_counts": health_counts,
+            "risk_counts": risk_counts,
+            "event_counts": event_counts,
+            "last_market_insight": self.statuses[-1].get("market_insight") if self.statuses else None,
+            "memory_entries": len(memory_entries),
         }
+
+
+def _count_values(values: Iterable[object]) -> dict:
+    """Count non-empty values in deterministic key order."""
+    counts: dict = {}
+    for value in values:
+        if value is None:
+            continue
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
 
 
 class FreysaSimulation:
@@ -133,6 +162,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         "--generate-template",
         action="store_true",
         help="Print a template scenario JSON to stdout and exit.",
+    )
+    parser.add_argument(
+        "--events",
+        action="store_true",
+        help="Include deterministic event counts when printing a full run.",
     )
     return parser.parse_args(argv)
 
@@ -203,6 +237,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(json.dumps(result.summary(), indent=2))
     else:
         display_statuses(result.statuses)
+        if args.events:
+            print("\n==== event counts ====")
+            print(json.dumps(result.summary()["event_counts"], indent=2))
         print("\n==== memory dump ====")
         print(result.memory_dump)
     return 0

--- a/tests/test_freysa0.py
+++ b/tests/test_freysa0.py
@@ -62,3 +62,24 @@ class TestFreysaSimulation:
 
         memory = json.loads(result.memory_dump)
         assert len(memory) > 0
+
+    def test_summary_includes_risk_health_and_event_counts(self):
+        scenario = FreysaScenario(
+            agent_name="SummaryAgent",
+            agent_version="0.2",
+            start_time=1000,
+            updates=[
+                ScenarioUpdate(offset=0, price_feed={"BTC": 100.0}),
+                ScenarioUpdate(offset=1, price_feed={"BTC": 700_000_000_000.0}),
+            ],
+        )
+
+        result = FreysaSimulation(scenario).run()
+        summary = result.summary()
+
+        assert summary["cycles"] == 2
+        assert summary["spike_cycles"] == 1
+        assert summary["health_counts"] == {"active": 1, "idle": 1}
+        assert summary["risk_counts"] == {"critical": 1, "normal": 1}
+        assert summary["event_counts"]["market_analysis"] == 2
+        assert summary["last_market_insight"]["spike_detected"] is True

--- a/tests/test_freysa_agent.py
+++ b/tests/test_freysa_agent.py
@@ -79,3 +79,46 @@ class TestFreysaAgent:
         assert limiter.spike({"ETH": SimpleLimiter.ETH_SPIKE + 1})
         # AVG SPIKE is 6_290_000_000.0
         assert limiter.spike({"A": 7_000_000_000.0})
+
+    def test_market_insight_tracks_risk_and_trend(self):
+        agent = FreysaSentientAI()
+
+        first = agent.run_cycle(
+            {"price_feed": {"btc": 100.0, "ETH": 300.0}, "messages": [" baseline "]},
+            current_time=10,
+        )
+        assert first["market_insight"]["asset_count"] == 2
+        assert first["market_insight"]["average_price"] == 200.0
+        assert first["market_insight"]["trend"] == "baseline"
+        assert first["market_insight"]["risk_level"] == "normal"
+        assert first["last_message"] == "baseline"
+
+        second = agent.run_cycle(
+            {"price_feed": {"BTC": SimpleLimiter.BTC_SPIKE + 1, "ETH": 500.0}},
+            current_time=20,
+        )
+        assert second["state"]["health"] == "active"
+        assert second["market_insight"]["trend"] == "rising"
+        assert second["market_insight"]["risk_level"] == "critical"
+        assert second["market_insight"]["spike_detected"] is True
+
+    def test_input_normalization_warns_and_recent_memory_filters(self):
+        agent = FreysaSentientAI()
+        status = agent.run_cycle(
+            {
+                "price_feed": {
+                    " btc ": "42.5",
+                    "BAD": "nope",
+                    "NEG": -1,
+                },
+                "messages": [" ok ", "", 12],
+                "extra": "ignored",
+            },
+            current_time=50,
+        )
+
+        assert status["state"]["inputs"]["price_feed"] == {"BTC": 42.5}
+        assert status["state"]["inputs"]["messages"] == ["ok"]
+        assert status["event_counts"]["warn"] == 3
+        warnings = agent.recent_memory(limit=10, event="warn")
+        assert [entry["event"] for entry in warnings] == ["warn", "warn", "warn"]


### PR DESCRIPTION
### Motivation

- Provide richer, deterministic diagnostics so simulation runs produce compact market insights (trend, spread, risk, spike) for easier analysis and auditing.
- Harden oracle input handling to avoid silent failures from malformed feeds or messages and to make normalization deterministic.
- Expose lightweight event and memory utilities to simplify downstream analysis and CLI reporting.

### Description

- Add a `MarketInsight` dataclass and deterministic market analysis (`_analyze_market`, `_trend`, `_risk_level`) that computes asset count, avg/min/max prices, spread, trend, risk level, and spike detection on each cycle, and include it in the agent status (`agents/freysa_agent.py`).
- Harden oracle ingestion by normalizing asset symbols, validating finite non-negative prices, warning on rejected/ignored fields, trimming/truncating and normalizing messages, and logging these warnings; also add `SimpleLimiter.explain`, `event_counts()`, and `recent_memory()` helpers for diagnostics.
- Wire market analysis into the main cycle path (run -> ingest -> analyze -> reflect -> self-update) and enrich `get_status()` to return `market_insight` and deterministic event counts.
- Extend the CLI/simulation (`freysa0.py`) to produce richer `SimulationResult.summary()` with spike, health, risk, and event counts, add a `--events` flag to show a compact event section, and update README to document the new diagnostics and CLI usage.
- Add and expand tests to cover market insight generation, input normalization warnings, recent-memory filtering, and the improved simulation summary (`tests/test_freysa_agent.py`, `tests/test_freysa0.py`).

### Testing

- Ran the full test suite with `pytest -q`, and all tests passed (suite completed successfully). 
- Verified code compiles with `python -m py_compile agents/freysa_agent.py freysa0.py` with no errors. 
- Exercised the CLI helpers by generating a template and running the simulation with `--summary` and `--events`, and inspected the produced summaries and event counts; these runs completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faeb443e208327a9cb71230b76ac22)