### PR TITLE
Enhance Freysa analytics and scenario validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ market scenarios while keeping the runtime deterministic and auditable.
 The module exposes the `FreysaSentientAI` class, a deterministic agent core that
 operates on simple oracle payloads containing price feeds and textual messages.
 It supports dependency injection for clocks and limiter policies, keeps a bounded
-memory log, and produces structured status snapshots after each reasoning cycle.
+memory log, computes deterministic per-cycle market analytics, and produces
+structured status snapshots after each reasoning cycle.
 
 ### `freysa0.py`
 The script offers a command-line interface around the agent to make it easy to
@@ -62,17 +63,26 @@ If you only need a concise view, use the `--summary` flag:
 python freysa0.py scenario.json --summary
 ```
 
+To focus review on anomalous activity, print only cycles that generated alerts:
+
+```
+python freysa0.py scenario.json --alerts-only
+```
+
 ### 3. Interpreting the results
 
 Each cycle status includes:
 - the agent metadata (`name`, `version`, deterministic `id`),
 - the internal state snapshot (awareness, health, inputs, etc.),
 - the average asset price for the current cycle (when available),
+- deterministic analysis with per-asset price moves, trend, risk score, risk
+  level, message signal, and generated alerts,
 - the most recent message seen by the agent, and
 - how many memory entries are currently stored.
 
 The memory log at the end reveals every logged event in chronological order,
-providing full traceability of the reasoning path the agent followed.
+including oracle validation warnings and analysis events, providing full
+traceability of the reasoning path the agent followed.
 
 ## Development
 
@@ -89,6 +99,9 @@ pytest
 
 - Implement a custom limiter by subclassing `agents.freysa_agent.SimpleLimiter`
   and injecting it into the `FreysaSimulation` helper.
+- Tune the deterministic risk model by adjusting the movement threshold, message
+  signal keywords, or limiter thresholds in `agents.freysa_agent.FreysaSentientAI`
+  and `agents.freysa_agent.SimpleLimiter`.
 - Replace the static clock with a more sophisticated deterministic clock that
   matches your environment.
 - Build higher-level analytics by importing the `FreysaSimulation` class from

--- a/agents/freysa_agent.py
+++ b/agents/freysa_agent.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Dict, List, Optional, Protocol, TypeAlias, final
 
@@ -38,6 +39,34 @@ class InputBundle:
         return asdict(self)
 
 
+@dataclass(slots=True, frozen=True)
+class PriceMove:
+    """Per-asset movement between the previous and current oracle snapshots."""
+
+    asset: str
+    previous: Optional[float]
+    current: float
+    change: Optional[float]
+    change_pct: Optional[float]
+    direction: str
+
+
+@dataclass(slots=True, frozen=True)
+class CycleAnalysis:
+    """Deterministic analytics derived during a single reasoning cycle."""
+
+    avg_price: Optional[float] = None
+    price_moves: List[PriceMove] = field(default_factory=list)
+    trend: str = "unknown"
+    risk_score: int = 0
+    risk_level: str = "low"
+    message_signal: str = "neutral"
+    alerts: List[str] = field(default_factory=list)
+
+    def to_json(self) -> JSON:
+        return asdict(self)
+
+
 @dataclass(slots=True)
 class SelfState:
     awareness: str = "observing"
@@ -45,6 +74,7 @@ class SelfState:
     health: str = "idle"
     inputs: InputBundle = field(default_factory=InputBundle)
     cycle_count: int = 0
+    analysis: CycleAnalysis = field(default_factory=CycleAnalysis)
 
     def snapshot(self) -> JSON:
         return asdict(self)
@@ -95,6 +125,12 @@ class SimpleLimiter:
 @final
 class FreysaSentientAI:
     MAX_MEMORY: Optional[int] = 2_048  # smaller default for on-chain cost
+    PRICE_MOVE_ALERT_PCT = 5.0
+    MESSAGE_SIGNALS = {
+        "urgent": {"panic", "urgent", "emergency", "crash", "exploit", "hack"},
+        "positive": {"buy", "bull", "rally", "growth", "thanks"},
+        "inquiry": {"status", "status?", "why", "how", "what", "?"},
+    }
 
     def __init__(
         self,
@@ -113,6 +149,7 @@ class FreysaSentientAI:
 
         self.state = SelfState()
         self.memory: List[LogEntry] = []
+        self._previous_price_feed: Optional[Dict[str, float]] = None
 
         # Genesis event always at t=0
         self._log("boot", {"agent_id": self.id, "version": self.version}, timestamp=0)
@@ -136,8 +173,10 @@ class FreysaSentientAI:
             return self.get_status()
 
         self._ingest_oracle(oracle_payload, timestamp=now)
+        self._analyze_cycle(timestamp=now)
         self._reflect(timestamp=now)
         self._self_update(timestamp=now)  # decides final health
+        self._remember_price_feed()
         return self.get_status()
 
     def export_memory(self, pretty: bool = False) -> str:
@@ -151,6 +190,7 @@ class FreysaSentientAI:
     def reset_memory(self) -> None:
         self.memory.clear()
         self.state = SelfState()
+        self._previous_price_feed = None
         self._log("reset", {"agent_id": self.id}, timestamp=0)
 
     def get_status(self) -> JSON:
@@ -164,6 +204,7 @@ class FreysaSentientAI:
             "state": self.state.snapshot(),
             "avg_price": avg_price,
             "last_message": messages[-1] if messages else None,
+            "analysis": self.state.analysis.to_json(),
             "memory_length": len(self.memory),
         }
 
@@ -174,6 +215,9 @@ class FreysaSentientAI:
         """Validate and store incoming oracle data deterministically."""
         allowed = {f.name for f in fields(InputBundle)}
         filtered = {k: payload[k] for k in payload if k in allowed}
+        ignored = sorted(k for k in payload if k not in allowed)
+        if ignored:
+            self._log("warn", {"reason": "ignored oracle keys", "keys": ignored}, timestamp=timestamp)
 
         # -- price feed -------------------------------------------------- #
         pf_raw = filtered.get("price_feed")
@@ -188,10 +232,26 @@ class FreysaSentientAI:
 
     def _validate_price_feed(self, pf_raw: Any, timestamp: int) -> Optional[Dict[str, float]]:
         if isinstance(pf_raw, dict):
-            try:
-                return {k: float(v) for k, v in pf_raw.items()}
-            except (ValueError, TypeError):
-                self._log("warn", {"reason": "non-numeric price values"}, timestamp=timestamp)
+            price_feed: Dict[str, float] = {}
+            for asset, value in pf_raw.items():
+                try:
+                    price = float(value)
+                except (ValueError, TypeError):
+                    self._log(
+                        "warn",
+                        {"reason": "non-numeric price value", "asset": str(asset)},
+                        timestamp=timestamp,
+                    )
+                    continue
+                if not math.isfinite(price) or price < 0:
+                    self._log(
+                        "warn",
+                        {"reason": "invalid price value", "asset": str(asset)},
+                        timestamp=timestamp,
+                    )
+                    continue
+                price_feed[str(asset).upper()] = price
+            return price_feed or None
         else:
             if pf_raw is not None:
                 self._log("warn", {"reason": "price_feed not dict"}, timestamp=timestamp)
@@ -199,28 +259,159 @@ class FreysaSentientAI:
 
     def _validate_messages(self, msgs_raw: Any, timestamp: int) -> Optional[List[str]]:
         if isinstance(msgs_raw, list) and all(isinstance(m, str) for m in msgs_raw):
-            return msgs_raw
+            cleaned = [message.strip() for message in msgs_raw if message.strip()]
+            return cleaned or None
         else:
             if msgs_raw is not None:
                 self._log("warn", {"reason": "messages not list[str]"}, timestamp=timestamp)
         return None
 
+    def _analyze_cycle(self, *, timestamp: int) -> None:
+        """Compute deterministic market movement, message signal, and risk level."""
+        price_feed = self.state.inputs.price_feed or {}
+        messages = self.state.inputs.messages or []
+        avg_price = round(sum(price_feed.values()) / len(price_feed), 2) if price_feed else None
+        price_moves = self._price_moves(price_feed)
+        message_signal = self._message_signal(messages)
+        risk_score, risk_level, alerts = self._risk_assessment(
+            price_feed=price_feed,
+            price_moves=price_moves,
+            message_signal=message_signal,
+        )
+        trend = self._trend(price_moves)
+        self.state.analysis = CycleAnalysis(
+            avg_price=avg_price,
+            price_moves=price_moves,
+            trend=trend,
+            risk_score=risk_score,
+            risk_level=risk_level,
+            message_signal=message_signal,
+            alerts=alerts,
+        )
+        self._log("analysis", self.state.analysis.to_json(), timestamp=timestamp)
+
+    def _price_moves(self, price_feed: Dict[str, float]) -> List[PriceMove]:
+        moves: List[PriceMove] = []
+        for asset in sorted(price_feed):
+            current = price_feed[asset]
+            previous = (self._previous_price_feed or {}).get(asset)
+            change = current - previous if previous is not None else None
+            change_pct = None
+            if previous not in (None, 0):
+                change_pct = round((change or 0.0) / previous * 100, 4)
+            direction = self._direction(change_pct)
+            moves.append(
+                PriceMove(
+                    asset=asset,
+                    previous=previous,
+                    current=current,
+                    change=round(change, 8) if change is not None else None,
+                    change_pct=change_pct,
+                    direction=direction,
+                )
+            )
+        return moves
+
+    def _message_signal(self, messages: List[str]) -> str:
+        tokens = {token.strip(".,!;:()[]{}").lower() for message in messages for token in message.split()}
+        compact_messages = " ".join(messages).lower()
+        if tokens & self.MESSAGE_SIGNALS["urgent"]:
+            return "urgent"
+        if tokens & self.MESSAGE_SIGNALS["positive"]:
+            return "positive"
+        if tokens & self.MESSAGE_SIGNALS["inquiry"] or "?" in compact_messages:
+            return "inquiry"
+        return "neutral"
+
+    def _risk_assessment(
+        self,
+        *,
+        price_feed: Dict[str, float],
+        price_moves: List[PriceMove],
+        message_signal: str,
+    ) -> tuple[int, str, List[str]]:
+        score = 0
+        alerts: List[str] = []
+        if self.limiter.spike(price_feed):
+            score += 60
+            alerts.append("limiter threshold exceeded")
+
+        largest_abs_move = 0.0
+        for move in price_moves:
+            if move.change_pct is None:
+                continue
+            largest_abs_move = max(largest_abs_move, abs(move.change_pct))
+            if abs(move.change_pct) >= self.PRICE_MOVE_ALERT_PCT:
+                alerts.append(f"{move.asset} moved {move.change_pct}%")
+        score += min(30, int(largest_abs_move * 2))
+
+        if message_signal == "urgent":
+            score += 15
+            alerts.append("urgent operator message detected")
+        elif message_signal == "inquiry":
+            score += 3
+
+        if not price_feed:
+            score += 5
+            alerts.append("missing price feed")
+
+        score = min(score, 100)
+        if score >= 80:
+            level = "critical"
+        elif score >= 55:
+            level = "elevated"
+        elif score >= 25:
+            level = "moderate"
+        else:
+            level = "low"
+        return score, level, alerts
+
+    def _trend(self, price_moves: List[PriceMove]) -> str:
+        known = [move for move in price_moves if move.change_pct is not None]
+        if not known:
+            return "unknown"
+        positive = sum(1 for move in known if move.change_pct and move.change_pct > 0)
+        negative = sum(1 for move in known if move.change_pct and move.change_pct < 0)
+        if positive > negative:
+            return "rising"
+        if negative > positive:
+            return "falling"
+        return "mixed"
+
+    def _direction(self, change_pct: Optional[float]) -> str:
+        if change_pct is None:
+            return "new"
+        if change_pct > 0:
+            return "up"
+        if change_pct < 0:
+            return "down"
+        return "flat"
+
     def _reflect(self, *, timestamp: int) -> None:
         """Lightweight metacognition placeholder."""
         last_event = self.memory[-1].event if self.memory else "none"
-        thought = f"reflecting on {last_event}"
+        thought = f"reflecting on {last_event}; risk={self.state.analysis.risk_level}"
         self.state.awareness = "reflecting"
         self._log("reflect", {"thought": thought}, timestamp=timestamp)
         self.state.awareness = "observing"
 
     def _self_update(self, *, timestamp: int) -> None:
-        """Adjust internal health/state based on limiter policy."""
+        """Adjust internal health/state based on limiter and analysis policies."""
         pf = self.state.inputs.price_feed or {}
         high_activity = self.limiter.spike(pf)
+        risky_activity = self.state.analysis.risk_level in {"elevated", "critical"}
 
-        action = "high market activity" if high_activity else "normal range"
-        self.state.health = "active" if high_activity else "idle"
+        if high_activity or risky_activity:
+            action = f"monitoring {self.state.analysis.risk_level} activity"
+            self.state.health = "active"
+        else:
+            action = "normal range"
+            self.state.health = "idle"
         self._log("self_update", {"action": action}, timestamp=timestamp)
+
+    def _remember_price_feed(self) -> None:
+        if self.state.inputs.price_feed:
+            self._previous_price_feed = dict(self.state.inputs.price_feed)
 
     # ------------------------------------------------------------------- #
     #  Logging

--- a/freysa0.py
+++ b/freysa0.py
@@ -86,12 +86,19 @@ class SimulationResult:
         cycles = len(self.statuses)
         last_state = self.statuses[-1]["state"] if self.statuses else {}
         last_health = last_state.get("health")
+        analyses = [status.get("analysis", {}) for status in self.statuses]
         avg_prices = [status.get("avg_price") for status in self.statuses if status.get("avg_price")]
+        avg_risks = [analysis.get("risk_score", 0) for analysis in analyses]
         avg_price = sum(avg_prices) / len(avg_prices) if avg_prices else None
+        peak_risk = max(avg_risks) if avg_risks else 0
+        alert_count = sum(len(analysis.get("alerts", [])) for analysis in analyses)
         return {
             "cycles": cycles,
             "last_health": last_health,
             "avg_price_mean": round(avg_price, 2) if avg_price is not None else None,
+            "peak_risk_score": peak_risk,
+            "alert_count": alert_count,
+            "final_trend": analyses[-1].get("trend") if analyses else None,
             "memory_entries": len(json.loads(self.memory_dump) if self.memory_dump else []),
         }
 
@@ -134,6 +141,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         action="store_true",
         help="Print a template scenario JSON to stdout and exit.",
     )
+    parser.add_argument(
+        "--alerts-only",
+        action="store_true",
+        help="Print only cycles with non-empty analysis alerts.",
+    )
     return parser.parse_args(argv)
 
 
@@ -168,11 +180,30 @@ def load_scenario(path: Path) -> FreysaScenario:
     raw = json.loads(path.read_text())
     if not isinstance(raw, dict):
         raise ValueError("Scenario file must contain a JSON object")
-    return FreysaScenario.from_json(raw)
+    scenario = FreysaScenario.from_json(raw)
+    validate_scenario(scenario)
+    return scenario
 
 
-def display_statuses(statuses: Iterable[dict]) -> None:
+def validate_scenario(scenario: FreysaScenario) -> None:
+    """Fail fast on malformed deterministic scenarios before running cycles."""
+    if not scenario.updates:
+        raise ValueError("Scenario must contain at least one update")
+    previous_offset = None
+    for index, update in enumerate(scenario.updates, start=1):
+        if update.offset < 0:
+            raise ValueError(f"Update {index} has a negative offset")
+        if previous_offset is not None and update.offset < previous_offset:
+            raise ValueError("Scenario update offsets must be sorted ascending")
+        if update.price_feed is None and update.messages is None:
+            raise ValueError(f"Update {index} must include price_feed or messages")
+        previous_offset = update.offset
+
+
+def display_statuses(statuses: Iterable[dict], *, alerts_only: bool = False) -> None:
     for index, status in enumerate(statuses, start=1):
+        if alerts_only and not status.get("analysis", {}).get("alerts"):
+            continue
         print(f"\n--- cycle {index} ---")
         print(json.dumps(status, indent=2))
 
@@ -202,7 +233,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.summary:
         print(json.dumps(result.summary(), indent=2))
     else:
-        display_statuses(result.statuses)
+        display_statuses(result.statuses, alerts_only=args.alerts_only)
         print("\n==== memory dump ====")
         print(result.memory_dump)
     return 0

--- a/tests/test_freysa0.py
+++ b/tests/test_freysa0.py
@@ -62,3 +62,33 @@ class TestFreysaSimulation:
 
         memory = json.loads(result.memory_dump)
         assert len(memory) > 0
+
+    def test_summary_includes_analysis_fields(self):
+        scenario = FreysaScenario(
+            agent_name="SummaryAgent",
+            agent_version="0.2",
+            start_time=1000,
+            updates=[
+                ScenarioUpdate(offset=0, price_feed={"BTC": 100.0}, messages=["start"]),
+                ScenarioUpdate(offset=10, price_feed={"BTC": 110.0}, messages=["urgent crash"]),
+            ],
+        )
+
+        result = FreysaSimulation(scenario).run()
+        summary = result.summary()
+
+        assert summary["peak_risk_score"] >= 30
+        assert summary["alert_count"] >= 2
+        assert summary["final_trend"] == "rising"
+
+    def test_load_scenario_rejects_unsorted_offsets(self, tmp_path):
+        f = tmp_path / "scenario.json"
+        f.write_text(json.dumps({
+            "updates": [
+                {"offset": 10, "messages": ["late"]},
+                {"offset": 5, "messages": ["early"]},
+            ]
+        }))
+
+        with pytest.raises(ValueError, match="offsets"):
+            load_scenario(f)

--- a/tests/test_freysa_agent.py
+++ b/tests/test_freysa_agent.py
@@ -79,3 +79,32 @@ class TestFreysaAgent:
         assert limiter.spike({"ETH": SimpleLimiter.ETH_SPIKE + 1})
         # AVG SPIKE is 6_290_000_000.0
         assert limiter.spike({"A": 7_000_000_000.0})
+
+    def test_analysis_tracks_price_moves_and_risk(self):
+        agent = FreysaSentientAI()
+        agent.run_cycle({"price_feed": {"BTC": 100.0, "ETH": 50.0}, "messages": ["baseline"]}, current_time=1)
+        status = agent.run_cycle(
+            {"price_feed": {"BTC": 110.0, "ETH": 45.0}, "messages": ["urgent crash?"]},
+            current_time=2,
+        )
+
+        analysis = status["analysis"]
+        assert analysis["trend"] == "mixed"
+        assert analysis["message_signal"] == "urgent"
+        assert analysis["risk_score"] >= 30
+        assert "urgent operator message detected" in analysis["alerts"]
+        btc_move = next(move for move in analysis["price_moves"] if move["asset"] == "BTC")
+        assert btc_move["change_pct"] == 10.0
+        assert btc_move["direction"] == "up"
+
+    def test_validation_filters_bad_price_values_and_normalizes_assets(self):
+        agent = FreysaSentientAI()
+        status = agent.run_cycle(
+            {"price_feed": {"btc": "123.45", "BAD": "nope", "NEG": -1}, "messages": ["  hello  ", ""]},
+            current_time=10,
+        )
+
+        assert status["state"]["inputs"]["price_feed"] == {"BTC": 123.45}
+        assert status["state"]["inputs"]["messages"] == ["hello"]
+        events = [entry.event for entry in agent.memory]
+        assert events.count("warn") == 2


### PR DESCRIPTION
### Motivation

- Provide deterministic per-cycle market analytics (price moves, trend, message signals, risk scoring and alerts) so simulations expose richer, auditable signals.  
- Harden oracle ingestion to reject or normalize malformed inputs and surface validation warnings deterministically.  
- Improve the simulation CLI and summaries to make alert inspection and scenario validation easier.  

### Description

- Add analytics data types `PriceMove` and `CycleAnalysis` and surface analysis in `FreysaSentientAI` status via `analysis` in `get_status()`.  
- Implement deterministic analysis pipeline: `_analyze_cycle`, `_price_moves`, `_message_signal`, `_risk_assessment`, `_trend`, and `_direction`, and call it each cycle.  
- Harden input validation by normalizing asset symbols, filtering non-finite/negative prices, trimming messages, logging ignored payload keys, and preserving warning events.  
- Extend `freysa0.py` with `validate_scenario()` to fail fast on empty/negative/unsorted updates, add `--alerts-only` CLI flag, and expand `SimulationResult.summary()` with `peak_risk_score`, `alert_count`, and `final_trend`.  

### Testing

- Ran the full test suite with `pytest -q` and all tests passed.  
- Verified modules compile with `python -m py_compile agents/freysa_agent.py freysa0.py` with no errors.  
- Exercised the CLI template and summary flow with `python freysa0.py --generate-template` and `python freysa0.py <template> --summary`, which produced the expected summary fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faeb5d87e88327b2952618f6e6baae)